### PR TITLE
Make project compilable against PhpStorm 9 SDK

### DIFF
--- a/src/main/java/cz/juzna/intellij/neon/editor/NeonStructureViewFactory.java
+++ b/src/main/java/cz/juzna/intellij/neon/editor/NeonStructureViewFactory.java
@@ -5,6 +5,7 @@ import com.intellij.ide.structureView.StructureViewModel;
 import com.intellij.ide.structureView.StructureViewModelBase;
 import com.intellij.ide.structureView.TreeBasedStructureViewBuilder;
 import com.intellij.lang.PsiStructureViewFactory;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.psi.PsiFile;
 import cz.juzna.intellij.neon.psi.NeonFile;
 import org.jetbrains.annotations.NotNull;
@@ -20,9 +21,8 @@ public class NeonStructureViewFactory implements PsiStructureViewFactory {
 		return new TreeBasedStructureViewBuilder() {
 			@NotNull
 			@Override
-			public StructureViewModel createStructureViewModel() {
+			public StructureViewModel createStructureViewModel(Editor editor) {
 				return new StructureViewModelBase(file, new NeonStructureViewElement(file));
-//				return new NeonStructureViewModel(file);
 			}
 		};
 	}


### PR DESCRIPTION
Right now, the project is not compilable with PhpStorm 9 SDK, probably because the API of TreeBasedStructureViewBuilder  was changed back in January with this commit https://github.com/JetBrains/intellij-community/commit/f1fa0838a03e3ae3b5f16d74ee99d017f90c8483